### PR TITLE
Adds trophia-groomer image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DOCKERS := \
 	ubuntu/texlive-r \
 	ubuntu/gorbachev-base \
 	ubuntu/stencila-r \
+	ubuntu/trophia-groomer \
 	ubuntu/kahawai-build \
 	ubuntu/layers-build
 
@@ -33,6 +34,7 @@ ubuntu/texlive/.docker: ubuntu/nz/.docker
 ubuntu/texlive-r/.docker: ubuntu/texlive/.docker
 ubuntu/gorbachev-base/.docker: ubuntu/texlive-r/.docker
 ubuntu/stencila-r/.docker: ubuntu/gorbachev-base/.docker
+ubuntu/trophia-groomer/.docker: ubuntu/gorbachev-base/.docker
 
 ubuntu/kahawai-build/.docker: ubuntu/nz/.docker
 ubuntu/layers-build/.docker: ubuntu/kahawai-build/.docker

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ docker.tridentsystems.co.nz/ubuntu/nz
 docker.tridentsystems.co.nz/ubuntu/layers-build
 docker.tridentsystems.co.nz/ubuntu/kahawai-build
 docker.tridentsystems.co.nz/ubuntu/stencila-r
+docker.tridentsystems.co.nz/ubuntu/trophia-groomer
 docker.tridentsystems.co.nz/ubuntu/gorbachev-base
 docker.tridentsystems.co.nz/ubuntu/texlive-r
 docker.tridentsystems.co.nz/ubuntu/texlive

--- a/ubuntu/trophia-groomer/Dockerfile
+++ b/ubuntu/trophia-groomer/Dockerfile
@@ -1,0 +1,19 @@
+# A Docker image for running https://github.com/trophia/groomer, which apparently does
+# "Grooming (and other things!) for New Zealand fisheries catch and effort data", on the
+# Kahawai infrastructure. Doesn't need all the R stuff in gorbachev-base so, primarily for build
+# speed during development, just using Trusty as a base
+
+FROM ubuntu:14.04
+
+MAINTAINER nokome@trophia.com
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get install -y git python \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/trophia/groomer.git
+
+RUN cd groomer \
+  && git pull \
+  && git checkout 5565884


### PR DESCRIPTION
Adds a Docker image for running https://github.com/trophia/groomer, which apparently does
"Grooming (and other things!) for New Zealand fisheries catch and effort data", on the
Kahawai infrastructure. Doesn't need all the R stuff in gorbachev-base so, primarily for build
speed during development, just using Trusty as a base.

Suggestions welcome.
